### PR TITLE
Fix webpack loader config

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -6,17 +6,20 @@
 
 const path = require("path");
 
-exports.onCreateWebpackConfig = ({ stage, actions }) => {
-  switch (stage) {
-    case `build-html`:
+exports.onCreateWebpackConfig = ({ stage, actions, loaders }) => {
+  if (stage === `build-html`) {
     actions.setWebpackConfig({
-      loader: ("null", {
-        test: /webfontloader/,
-        loader: "null-loader",
-      }),
+      module: {
+        rules: [
+          {
+            test: /webfontloader/,
+            use: loaders.null(),
+          },
+        ],
+      },
     })
   }
-};
+}
 
 exports.createPages = ({ actions, graphql }) => {
   const { createPage } = actions;


### PR DESCRIPTION
## Summary
- correct Webpack config for webfontloader in `gatsby-node.js`

## Testing
- `npm test` *(fails: Error: no test specified)*
- `yarn format` *(fails: package missing; Yarn couldn't install dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6874b3a9f598832ca894bbd132a36a3a