### PR TITLE
Fix missing closing brace in ProjectTitle media query and enable xxxlarge grid layout

### DIFF
--- a/src/components/Project/projectGrid.js
+++ b/src/components/Project/projectGrid.js
@@ -29,10 +29,10 @@ const Projects = styled.section`
     grid-auto-rows: calc(100vw / 3 + 100px);
   }
 
-  /* @media ${(props) => props.theme.xxxlargeUp} {
+  @media ${(props) => props.theme.xxxlargeUp} {
     grid-template-columns: 1fr 1fr 1fr 1fr;
     grid-auto-rows: calc(25vw + 100px);
-  } */
+  }
 `
 class ProjectGrid extends React.Component {
   constructor(props) {

--- a/src/templates/projectTemplate.js
+++ b/src/templates/projectTemplate.js
@@ -194,6 +194,7 @@ const ProjectTitle = styled.h1`
 
   @media ${(props) => props.theme.largeUp} {
     font-size: ${rem(32)};
+  }
 `
 
 const ProjectType = styled.h2`


### PR DESCRIPTION
- Fix missing } closing the largeUp media query in ProjectTitle styled component
  in projectTemplate.js (was causing malformed CSS)
- Enable the commented-out xxxlargeUp 4-column grid layout in projectGrid.js
  for screens ≥2400px wide

https://claude.ai/code/session_01CoDi6mepWoDeEqKz4agmzT